### PR TITLE
Ability to auto-login in a Laravel session

### DIFF
--- a/src/Subfission/Cas/CasManager.php
+++ b/src/Subfission/Cas/CasManager.php
@@ -96,7 +96,8 @@ class CasManager {
             'cas_debug'           => false,
             'cas_verbose_errors'  => false,
             'cas_masquerade'      => '',
-            'use_laravel_sessions'=> false
+            'use_laravel_sessions'=> false,
+            'user_cas_attribute'  => 'id'
         ];
 
         $this->config = array_merge($defaults, $config);

--- a/src/Subfission/Cas/CasManager.php
+++ b/src/Subfission/Cas/CasManager.php
@@ -95,7 +95,8 @@ class CasManager {
             'cas_enable_saml'     => true,
             'cas_debug'           => false,
             'cas_verbose_errors'  => false,
-            'cas_masquerade'      => ''
+            'cas_masquerade'      => '',
+            'use_laravel_sessions'=> false
         ];
 
         $this->config = array_merge($defaults, $config);

--- a/src/Subfission/Cas/Middleware/CASAuth.php
+++ b/src/Subfission/Cas/Middleware/CASAuth.php
@@ -28,6 +28,12 @@ class CASAuth
         {
             // Store the user credentials in a Laravel managed session
             session()->put('cas_user', $this->cas->user());
+            // manage the internal login process if the cas user is found in internal db
+            $config = $this->cas->getConfig();
+            $user = User::where($config['user_cas_attribute'], $this->cas->user())->first();
+            if (($config['use_laravel_sessions']) && (isset($user))) {
+                Auth::login($user);
+            }
         } else {
             if ($request->ajax()) {
                 return response('Unauthorized.', 401);

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -166,5 +166,12 @@ return [
     | The app needs to have a User class with Authenticatable interface.
     | https://laravel.com/docs/5.3/authentication#the-authenticatable-contract
      */
-    'use_laravel_sessions'      => env('CAS_USE_LARAVEL_SESSIONS', false)
+    'use_laravel_sessions'      => env('CAS_USE_LARAVEL_SESSIONS', false),
+    
+    /*
+    |--------------------------------------------------------------------------
+    | The User attribute that matches with the cas user id
+     */
+     'user_cas_id'  => env('CAS_USER_CAS_ID', 'id')
+
 ];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -158,5 +158,13 @@ return [
     | This should only be used for developmental purposes.  getAttributes()
     | will return null in this condition.
      */
-    'cas_masquerade'      => env('CAS_MASQUERADE', '')
+    'cas_masquerade'      => env('CAS_MASQUERADE', ''),
+    
+    /*
+    |--------------------------------------------------------------------------
+    | This will call the internal laravel authentication
+    | The app needs to have a User class with Authenticatable interface.
+    | https://laravel.com/docs/5.3/authentication#the-authenticatable-contract
+     */
+    'use_laravel_sessions'      => env('CAS_USE_LARAVEL_SESSIONS', false)
 ];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -172,6 +172,6 @@ return [
     |--------------------------------------------------------------------------
     | The User attribute that matches with the cas user id
      */
-     'user_cas_id'  => env('CAS_USER_CAS_ID', 'id')
+     'user_cas_attribute'  => env('CAS_USER_CAS_ATTRIBUTE', 'id')
 
 ];


### PR DESCRIPTION
The CAS authentication is separated from Laravel, the base behaviour is nice to keep things separated.
In some case, in my project for example, I'm using Zizaco/Entrust to help me to manage roles/permissions. I think there are a lot of packages related to the internal Laravel session.
That's why I added an option to the package to call or not the internal session mechanism.
I hope I did it correctly.
I know it could b done out of the package but I also think it's the middleware job.
Thanks for your reading.