### PR TITLE
[Issue#48] New CAS version selector string passed instead of expression

### DIFF
--- a/src/Subfission/Cas/CasManager.php
+++ b/src/Subfission/Cas/CasManager.php
@@ -74,11 +74,14 @@ class CasManager {
 		if ( $this->config['cas_enable_saml'] ) {
 			$server_type = SAML_VERSION_1_1;
 		} else {
+			// This allows the user to use 1.0, 2.0, etc as a string in the config
 			$cas_ver = 'CAS_VERSION_' . str_replace( '.', '_',
 					$this->config['cas_version'] );
 			if ( defined( $cas_ver ) ) {
-				$server_type = $cas_ver;
+				// We pull the phpCAS constant values as this is their definition
+				$server_type = constant($cas_ver);
 			} else {
+				// This will never be null, but can be invalid values for which we need to detect and substitute.
 				phpCAS::log( 'Invalid CAS version set; Reverting to defaults' );
 				$server_type = CAS_VERSION_2_0;
 			}

--- a/src/Subfission/Cas/CasManager.php
+++ b/src/Subfission/Cas/CasManager.php
@@ -75,12 +75,13 @@ class CasManager {
 			$server_type = SAML_VERSION_1_1;
 		} else {
 			// This allows the user to use 1.0, 2.0, etc as a string in the config
-			$cas_ver = 'CAS_VERSION_' . str_replace( '.', '_',
-					$this->config['cas_version'] );
-			if ( defined( $cas_ver ) ) {
-				// We pull the phpCAS constant values as this is their definition
-				$server_type = constant($cas_ver);
-			} else {
+			$cas_version_str = 'CAS_VERSION_' . str_replace( '.', '_', $this->config['cas_version'] );
+
+			// We pull the phpCAS constant values as this is their definition
+			// PHP will generate a E_WARNING if the version string is invalid which is helpful for troubleshooting
+			$server_type = constant($cas_version_str);
+
+			if ( is_null($server_type)  ) {
 				// This will never be null, but can be invalid values for which we need to detect and substitute.
 				phpCAS::log( 'Invalid CAS version set; Reverting to defaults' );
 				$server_type = CAS_VERSION_2_0;


### PR DESCRIPTION
This will patch issue 48 effectively while maintaining compatibility and provide more verbosity.