### PR TITLE
Fix Session storage bugs. (Terminate Laravel properly)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
   ],
   "require": {
     "php": ">=5.5.0",
+    "illuminate/http": "5.x",
     "illuminate/support": "5.x",
     "jasig/phpcas": "~1.3.4"
   },

--- a/src/Subfission/Cas/Exceptions/CasHttpResponseException.php
+++ b/src/Subfission/Cas/Exceptions/CasHttpResponseException.php
@@ -1,0 +1,18 @@
+<?php namespace Subfission\Cas\Exceptions;
+
+use CAS_GracefullTerminationException;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Symfony\Component\HttpFoundation\Response;
+
+class CasHttpResponseException extends HttpResponseException {
+	protected $gracefulTerminationException = null;
+
+	public function __construct( CAS_GracefullTerminationException $e ) {
+		$this->gracefulTerminationException = $e;
+		parent::__construct( Response::create() );
+	}
+
+	public function getException() {
+		return $this->gracefulTerminationException;
+	}
+}


### PR DESCRIPTION
Use HttpResponseException which can be handled by Laravel, instead of exit directly from phpCAS. So Laravel will be terminated properly. We got a complete life cycle from app bootstrap to response sent.