### PR TITLE
Update to Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
   "name": "subfission/cas",
-  "description": "Adds CAS to laravel 5.x",
+  "description": "Adds CAS to laravel 6.x",
   "keywords": [
     "CAS",
     "phpCAS",
     "SSO",
     "laravel",
-    "laravel 5"
+    "laravel 6"
   ],
   "license": "MIT",
   "authors": [
@@ -16,12 +16,12 @@
     }
   ],
   "require": {
-    "php": ">=5.5.0",
-    "illuminate/support": "5.x",
-    "apereo/phpcas": "~1.3.4"
+    "php": ">=7.2.0",
+    "illuminate/support": "6.x",
+    "apereo/phpcas": "^1.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.*"
+    "phpunit/phpunit": "^8.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Changes on prerequisities to match Laravel 6 ones.

I extracted the package into a local package to use the auth in my Laravel 6 project, it seems fine AFAIK but a quick test by the ruler of the package and some php unit tests i didn't do.
A v6 branch should be interesting also.