### PR TITLE
Update Illuminate/support Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require": {
     "php": ">=7.2.0",
-    "illuminate/support": "6.x",
+    "illuminate/support": "^6.0|^7.0",
     "apereo/phpcas": "^1.3"
   },
   "require-dev": {


### PR DESCRIPTION
Update Illuminate/support to 7.x to support installation in a laravel 7 project