### PR TITLE
Constrain phpcas package to 1.3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require": {
     "php": ">=7.2.0",
     "illuminate/support": "^6.0|^7.0|^8.0",
-    "apereo/phpcas": "^1.3"
+    "apereo/phpcas": "<=1.3.8"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0|^9.0"

--- a/src/Subfission/Cas/CasManager.php
+++ b/src/Subfission/Cas/CasManager.php
@@ -26,12 +26,7 @@ class CasManager {
 	public function __construct( array $config ) {
 		$this->parseConfig( $config );
 		if ( $this->config['cas_debug'] === true ) {
-			try {
-				phpCAS::setDebug();
-			} catch (ErrorException) {
-				// Fix for depreciation of setDebug
-				phpCAS::setLogger();
-			}
+            phpCAS::setDebug();
 			phpCAS::log( 'Loaded configuration:' . PHP_EOL
 			             . serialize( $config ) );
 		} else {


### PR DESCRIPTION
in response to a breaking change introduced in 1.3.9 (see https://github.com/apereo/phpCAS/issues/371)

This should provide short term relief from the issue introduced by the deprecation in the phpcas package.