### PR TITLE
Use latest phpcas

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require": {
     "php": ">=7.2.0",
     "illuminate/support": "^6.0|^7.0|^8.0",
-    "apereo/phpcas": "<=1.3.8"
+    "apereo/phpcas": ">=1.3.9"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0|^9.0"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require": {
     "php": ">=7.2.0",
     "illuminate/support": "^6.0|^7.0|^8.0",
-    "apereo/phpcas": "^1.3"
+    "apereo/phpcas": "<=1.3.8"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0|^9.0"

--- a/src/Subfission/Cas/CasManager.php
+++ b/src/Subfission/Cas/CasManager.php
@@ -26,12 +26,7 @@ class CasManager {
 	public function __construct( array $config ) {
 		$this->parseConfig( $config );
 		if ( $this->config['cas_debug'] === true ) {
-			try {
-				phpCAS::setDebug();
-			} catch (ErrorException) {
-				// Fix for depreciation of setDebug
-				phpCAS::setLogger();
-			}
+            phpCAS::setDebug();
 			phpCAS::log( 'Loaded configuration:' . PHP_EOL
 			             . serialize( $config ) );
 		} else {

--- a/src/Subfission/Cas/CasManager.php
+++ b/src/Subfission/Cas/CasManager.php
@@ -26,11 +26,9 @@ class CasManager {
 	public function __construct( array $config ) {
 		$this->parseConfig( $config );
 		if ( $this->config['cas_debug'] === true ) {
-            phpCAS::setDebug();
+			phpCAS::setLogger();
 			phpCAS::log( 'Loaded configuration:' . PHP_EOL
 			             . serialize( $config ) );
-		} else {
-			phpCAS::setDebug( $this->config['cas_debug'] );
 		}
 
 		phpCAS::setVerbose( $this->config['cas_verbose_errors'] );


### PR DESCRIPTION
This is the second part of handling the deprecation problem in the `apereo/phpcas` package. These these change can be tagged as a new release that requires the updated dependency. The version constraint needs to be reevaluated when the phpcas package makes a new release more in keeping with semver. The `>=` constraint will be a potential problem in the future.

If you choose to use this approach, PR #94 should be merged first and tagged as a patch release, then this one merged and tagged as at least a minor release.