### PR TITLE
Fix access to $config variable in CasManager

### DIFF
--- a/src/Subfission/Cas/CasManager.php
+++ b/src/Subfission/Cas/CasManager.php
@@ -77,7 +77,7 @@ class CasManager {
 			phpCAS::setLogger();
 		}
 		phpCAS::log( 'Loaded configuration:' . PHP_EOL
-			             . serialize( $config ) );
+			             . serialize( $this->config ) );
 	}
 	/**
 	 * Configure CAS Client|Proxy


### PR DESCRIPTION
Fix error introduced by commit 14bb0157ecabed48f9115181ab96fa0a621c081c and reported on a comment in issue #93