### PR TITLE
Refactor APP_DOMAIN and HTTPS_ONLY_COOKIES to config file

### DIFF
--- a/src/Subfission/Cas/CasManager.php
+++ b/src/Subfission/Cas/CasManager.php
@@ -42,8 +42,8 @@ class CasManager
 			session_set_cookie_params(
 				$this->config['cas_session_lifetime'],
 				$this->config['cas_session_path'],
-				env('APP_DOMAIN'),
-				env('HTTPS_ONLY_COOKIES'),
+				$this->config['cas_session_domain'],
+				$this->config['cas_session_secure'],
 				$this->config['cas_session_httponly']
 			);
 		}
@@ -162,7 +162,9 @@ class CasManager
 			'cas_version'          => "2.0",
 			'cas_debug'            => false,
 			'cas_verbose_errors'   => false,
-			'cas_masquerade'       => ''
+			'cas_masquerade'       => '',
+			'cas_session_domain'   => '',
+			'cas_session_secure'   => false,
 		];
 
 		$this->config = array_merge($defaults, $config);

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -140,7 +140,7 @@ return [
     |--------------------------------------------------------------------------
     */
     'cas_version' => env('CAS_VERSION', "2.0"),
-    
+
     /*
     |--------------------------------------------------------------------------
     | Enable PHPCas Debug Mode
@@ -166,5 +166,17 @@ return [
     | This should only be used for developmental purposes.  getAttributes()
     | will return null in this condition.
      */
-    'cas_masquerade' => env('CAS_MASQUERADE', '')
+    'cas_masquerade' => env('CAS_MASQUERADE', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | The value to set in the Domain field on cookies.
+     */
+    'cas_session_domain' => env('APP_DOMAIN', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Whether to add the Secure flag to cookies.
+     */
+    'cas_session_secure' => env('HTTPS_ONLY_COOKIES', false),
 ];


### PR DESCRIPTION
This allows the properties to be set even if config is cached. `env` calls do not work in this case - https://laravel.com/docs/9.x/configuration#:~:text=If%20you%20execute,level%20environment%20variables.