### PR TITLE
Updated for apereo/phpCAS 1.6 security issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require": {
     "php": ">=7.2.0",
     "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
-    "apereo/phpcas": "^1.3"
+    "apereo/phpcas": "^1.6"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0|^9.0",

--- a/src/Subfission/Cas/CasManager.php
+++ b/src/Subfission/Cas/CasManager.php
@@ -118,6 +118,7 @@ class CasManager
 			$this->config['cas_hostname'],
 			(int) $this->config['cas_port'],
 			$this->config['cas_uri'],
+			$this->config['cas_client_service'],
 			$this->config['cas_control_session']
 		);
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -61,6 +61,15 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Client service: host, port, protocol.
+    |--------------------------------------------------------------------------
+    | Example: 'http://localhost', 'https://example.com:8888'
+    */
+    'cas_client_service' => env('CAS_CLIENT_SERVICE', 'http://localhost'),
+
+
+    /*
+    |--------------------------------------------------------------------------
     | CAS Validation
     |--------------------------------------------------------------------------
     | CAS server SSL validation: 'self' for self-signed certificate, 'ca' for


### PR DESCRIPTION
Breaking change given the new number of function arguments.  Hotfix not an option.

Addresses [GHSA-8q72-6qq8-xv64](https://github.com/apereo/phpCAS/security/advisories/GHSA-8q72-6qq8-xv64)
