### PR TITLE
Add a check if cas client was already created when a new CasManager object is constructed

### DIFF
--- a/src/Subfission/Cas/CasManager.php
+++ b/src/Subfission/Cas/CasManager.php
@@ -48,7 +48,9 @@ class CasManager
 			);
 		}
 
-		$this->configureCas($this->config['cas_proxy'] ? 'proxy' : 'client');
+		// Only one client/proxy is allowed by phpCAS. 
+		// If phpCAS client was initialized already, do nothing.
+		phpCAS::getCasClient() ?? $this->configureCas($this->config['cas_proxy'] ? 'proxy' : 'client');
 
 		$this->configureCasValidation();
 


### PR DESCRIPTION
I run into a problem with using cas()->isAuthenticated() in a middleware where the application works correctly but I could not use pestphp for testing. The reason was that the middleware was evaluated a second time and the execution of ```CasManager::configureCas``` would try to create a second ```phpCAS::client``` which is not allowed. The result was that phpCAS would exit and as no exception was thrown, pestphp would just fail silently. A simple fix I found was to add a check in ```CasManager.php::__construct```.