### PR TITLE
Update cas proxy signatures

### DIFF
--- a/src/Subfission/Cas/CasManager.php
+++ b/src/Subfission/Cas/CasManager.php
@@ -182,7 +182,11 @@ class CasManager
          * Only do this when it looks like we have a comma separated list. Passing in an array
          * triggers autodiscovery downstream and we want to avoid that if possible.
          */
-        if (is_string($config['cas_client_service']) && strpos($config['cas_client_service'], ',') !== false) {
+        if (
+            isset($config['cas_client_service']) &&
+            is_string($config['cas_client_service']) &&
+            strpos($config['cas_client_service'], ',') !== false
+        ) {
             $config['cas_client_service'] = explode(',', $config['cas_client_service']);
         }
 

--- a/src/Subfission/Cas/CasManager.php
+++ b/src/Subfission/Cas/CasManager.php
@@ -177,6 +177,15 @@ class CasManager
             'cas_real_hosts'       => '',
         ];
 
+        /*
+         * If cas_client_service is a string, see if it contains a comma and split on it.
+         * Only do this when it looks like we have a comma separated list. Passing in an array
+         * triggers autodiscovery downstream and we want to avoid that if possible.
+         */
+        if (is_string($config['cas_client_service']) && strpos($config['cas_client_service'], ',') !== false) {
+            $config['cas_client_service'] = explode(',', $config['cas_client_service']);
+        }
+
         $this->config = array_merge($defaults, $config);
     }
 

--- a/src/Subfission/Cas/PhpCasProxy.php
+++ b/src/Subfission/Cas/PhpCasProxy.php
@@ -2,6 +2,7 @@
 
 namespace Subfission\Cas;
 
+use CAS_ServiceBaseUrl_Interface;
 use phpCAS;
 use Psr\Log\LoggerInterface;
 
@@ -67,26 +68,76 @@ class PhpCasProxy
         phpCAS::setLogger($logger);
     }
 
+    /**
+     * phpCAS client initializer.
+     *
+     * @param string                   $server_version  the version of the CAS server
+     * @param string                   $server_hostname the hostname of the CAS server
+     * @param int                      $server_port     the port the CAS server is running on
+     * @param string                   $server_uri      the URI the CAS server is responding on
+     * @param string|string[]|CAS_ServiceBaseUrl_Interface
+     *                                 $service_base_url the base URL (protocol, host and the
+     *                                                  optional port) of the CAS client; pass
+     *                                                  in an array to use auto discovery with
+     *                                                  an allowlist; pass in
+     *                                                  CAS_ServiceBaseUrl_Interface for custom
+     *                                                  behavior. Added in 1.6.0. Similar to
+     *                                                  serverName config in other CAS clients.
+     * @param bool                     $changeSessionID Allow phpCAS to change the session_id
+     *                                                  (Single Sign Out/handleLogoutRequests
+     *                                                  is based on that change)
+     * @param \SessionHandlerInterface $sessionHandler  the session handler
+     *
+     * @return void a newly created CAS_Client object
+     * @note Only one of the phpCAS::client() and phpCAS::proxy functions should be
+     * called, only once, and before all other methods (except phpCAS::getVersion()
+     * and phpCAS::setDebug()).
+     */
     public function client(
-        string $server_version,
-        string $server_hostname,
-        int $server_port,
-        string $server_uri,
-        string $service_base_url,
-        bool $changeSessionID = true,
-        \SessionHandlerInterface $sessionHandler = null
+        $server_version,
+        $server_hostname,
+        $server_port,
+        $server_uri,
+        $service_base_url,
+        $changeSessionID = true,
+        $sessionHandler = null
     ): void {
         phpCAS::client($server_version, $server_hostname, $server_port, $server_uri, $service_base_url, $changeSessionID, $sessionHandler);
     }
 
+    /**
+     * phpCAS proxy initializer.
+     *
+     * @param string                   $server_version  the version of the CAS server
+     * @param string                   $server_hostname the hostname of the CAS server
+     * @param string                   $server_port     the port the CAS server is running on
+     * @param string                   $server_uri      the URI the CAS server is responding on
+     * @param string|string[]|CAS_ServiceBaseUrl_Interface
+     *                                 $service_base_url the base URL (protocol, host and the
+     *                                                  optional port) of the CAS client; pass
+     *                                                  in an array to use auto discovery with
+     *                                                  an allowlist; pass in
+     *                                                  CAS_ServiceBaseUrl_Interface for custom
+     *                                                  behavior. Added in 1.6.0. Similar to
+     *                                                  serverName config in other CAS clients.
+     * @param bool                     $changeSessionID Allow phpCAS to change the session_id
+     *                                                  (Single Sign Out/handleLogoutRequests
+     *                                                  is based on that change)
+     * @param \SessionHandlerInterface $sessionHandler  the session handler
+     *
+     * @return void a newly created CAS_Client object
+     * @note Only one of the phpCAS::client() and phpCAS::proxy functions should be
+     * called, only once, and before all other methods (except phpCAS::getVersion()
+     * and phpCAS::setDebug()).
+     */
     public function proxy(
-        string $server_version,
-        string $server_hostname,
-        int $server_port,
-        string $server_uri,
-        string $service_base_url,
-        bool $changeSessionID = true,
-        \SessionHandlerInterface $sessionHandler = null
+        $server_version,
+        $server_hostname,
+        $server_port,
+        $server_uri,
+        $service_base_url,
+        $changeSessionID = true,
+        $sessionHandler = null
     ): void {
         phpCAS::proxy($server_version, $server_hostname, $server_port, $server_uri, $service_base_url, $changeSessionID, $sessionHandler);
     }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -65,7 +65,7 @@ return [
     |--------------------------------------------------------------------------
     | Example: 'http://localhost', 'https://example.com:8888'
     */
-    'cas_client_service' => env('CAS_CLIENT_SERVICE', 'http://localhost'),
+    'cas_client_service' => explode(',', env('CAS_CLIENT_SERVICE', 'http://localhost')),
 
 
     /*

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -65,7 +65,7 @@ return [
     |--------------------------------------------------------------------------
     | Example: 'http://localhost', 'https://example.com:8888'
     */
-    'cas_client_service' => explode(',', env('CAS_CLIENT_SERVICE', 'http://localhost')),
+    'cas_client_service' => env('CAS_CLIENT_SERVICE', 'http://localhost'),
 
 
     /*

--- a/tests/CasManagerTest.php
+++ b/tests/CasManagerTest.php
@@ -570,4 +570,31 @@ class CasManagerTest extends TestCase
     {
         return new CasManager($config, $this->casProxy, $this->sessionProxy, $this->logoutStrategy);
     }
+
+    public function testConfiguresCasWithServiceBaseArray(): void
+    {
+        $config = [
+            'cas_enable_saml' => false,
+            'cas_hostname' => $this->faker->domainName(),
+            'cas_port' => $this->faker->numberBetween(1, 1024),
+            'cas_uri' => $this->faker->url(),
+            'cas_client_service' => [$this->faker->url(), $this->faker->url()],
+            'cas_control_session' => $this->faker->boolean(),
+        ];
+
+        $this->casProxy->expects($this->once())->method('serverTypeCas')
+            ->willReturnArgument(0);
+
+        $this->casProxy->expects($this->once())->method('client')
+            ->with(
+                $this->anything(),
+                $this->equalTo($config['cas_hostname']),
+                $this->equalTo($config['cas_port']),
+                $this->equalTo($config['cas_uri']),
+                $this->equalTo($config['cas_client_service']),
+                $this->equalTo($config['cas_control_session'])
+            );
+
+        $this->makeCasManager($config);
+    }
 }


### PR DESCRIPTION
The proxy class added to facilitate testing used method signatures which do match the corresponding methods in the phpCAS class. This lead to issues with the service base argument not supporting all expected value types. The new signatures directly match the phpCAS class.